### PR TITLE
Enabling testsuite/integration/microprofile-tck/openapi to run against bootable jar

### DIFF
--- a/testsuite/integration/microprofile-tck/openapi/pom.xml
+++ b/testsuite/integration/microprofile-tck/openapi/pom.xml
@@ -216,6 +216,113 @@
                 </plugins>
             </build>
         </profile>
+
+        <!-- Test against bootable jar -->
+        <profile>
+            <id>bootablejar.profile</id>
+            <activation>
+                <property>
+                    <name>ts.bootable</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.wildfly.arquillian</groupId>
+                    <artifactId>wildfly-arquillian-container-bootable</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <!-- Disable the standard copy-based provisioning -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>ts.copy-wildfly</id>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.jboss.galleon</groupId>
+                        <artifactId>galleon-maven-plugin</artifactId>
+                        <executions>
+                            <!-- Disable the Galleon provisioning -->
+                            <execution>
+                                <id>microprofile-openapi-provisioning</id>
+                                <goals>
+                                    <goal>provisioning</goal>
+                                </goals>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-jar-maven-plugin</artifactId>
+                        <version>${version.org.wildfly.jar.plugin}</version>
+                        <executions>
+                            <!-- Package a cloud-server with openapi decorator added -->
+                            <execution>
+                                <id>bootable-jar-microprofile-openapi-packaging</id>
+                                <goals>
+                                    <goal>package</goal>
+                                </goals>
+                                <phase>process-test-resources</phase>
+                                <configuration>
+                                    <output-file-name>test-wildfly-openapi.jar</output-file-name>
+                                    <hollowJar>true</hollowJar>
+                                    <record-state>false</record-state>
+                                    <log-time>${galleon.log.time}</log-time>
+                                    <offline>true</offline>
+                                    <plugin-options>
+                                        <jboss-maven-dist/>
+                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                    </plugin-options>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
+                                            <artifactId>${testsuite.ee.galleon.pack.artifactId}</artifactId>
+                                            <version>${testsuite.ee.galleon.pack.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <layers>
+                                        <layer>cloud-server</layer>
+                                        <layer>microprofile-openapi</layer>
+                                    </layers>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <!-- Tests against the fault tolerance install  -->
+                        <configuration>
+                            <systemPropertyVariables>
+                                <install.dir>${project.build.directory}/wildfly</install.dir>
+                                <bootable.jar>${project.build.directory}/test-wildfly-openapi.jar</bootable.jar>
+                                <arquillian.xml>arquillian-bootable.xml</arquillian.xml>
+                            </systemPropertyVariables>
+                            <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
+                            <classpathDependencyExcludes>
+                                <classpathDependencyExclude>
+                                    org.wildfly.arquillian:wildfly-arquillian-container-managed
+                                </classpathDependencyExclude>
+                            </classpathDependencyExcludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
 </project>

--- a/testsuite/integration/microprofile-tck/openapi/src/test/resources/arquillian-bootable.xml
+++ b/testsuite/integration/microprofile-tck/openapi/src/test/resources/arquillian-bootable.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <defaultProtocol type="jmx-as7" />
+
+    <container qualifier="jboss" default="true">
+        <configuration>
+            <property name="installDir">${install.dir}</property>
+            <property name="jarFile">${bootable.jar}</property>
+
+            <property name="javaVmArguments">${server.jvm.args}</property>
+            <property name="jbossArguments">${jboss.args}</property>
+            <!-- -Djboss.inst is not necessarily needed, only in case the test case needs path to the instance it runs in.
+                 In the future, Arquillian should capable of injecting it into @ArquillianResource File or such. -->
+            <property name="allowConnectingToRunningServer">true</property>
+            <property name="managementAddress">${node0:127.0.0.1}</property>
+            <property name="managementPort">${as.managementPort:9990}</property>
+
+            <!-- AS7-4070 -->
+            <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
+            <property name="waitForPortsTimeoutInSeconds">8</property>
+        </configuration>
+    </container>
+
+</arquillian>


### PR DESCRIPTION
```
$ mvn clean test -Dts.bootable -Dmaven.repo.local=/home/fburzigo/projects/git/wildfly/wildfly/local-repo -DtestLogToFile=false -pl openapi/ -am
...
[INFO] Tests run: 230, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 36.846 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 230, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for WildFly Test Suite: Integration - MicroProfile TCK 21.0.0.Beta1-SNAPSHOT:
[INFO] 
[INFO] WildFly Test Suite: Integration - MicroProfile TCK . SUCCESS [  2.268 s]
[INFO] WildFly Test Suite: Integration - MicroProfile - OpenAPI TCK SUCCESS [ 45.036 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  48.186 s
[INFO] Finished at: 2020-08-18T10:26:41+02:00
[INFO] ------------------------------------------------------------------------
```