### PR TITLE
Fixing arquillian-bootable.xml contents in order to remove useless stuff and to use microptofile.jvm.args

### DIFF
--- a/testsuite/integration/microprofile-tck/config/src/test/resources/arquillian-bootable.xml
+++ b/testsuite/integration/microprofile-tck/config/src/test/resources/arquillian-bootable.xml
@@ -9,17 +9,12 @@
             <property name="installDir">${install.dir}</property>
             <property name="jarFile">${bootable.jar}</property>
 
-            <property name="javaVmArguments">${server.jvm.args}</property>
-            <property name="jbossArguments">${jboss.args}</property>
-            <!-- -Djboss.inst is not necessarily needed, only in case the test case needs path to the instance it runs in.
-                 In the future, Arquillian should capable of injecting it into @ArquillianResource File or such. -->
+            <property name="javaVmArguments">${microprofile.jvm.args}</property>
+            <property name="managementAddress">127.0.0.1</property>
+            <property name="managementPort">9990</property>
+            <property name="waitForPorts">9990</property>
             <property name="allowConnectingToRunningServer">true</property>
-            <property name="managementAddress">${node0:127.0.0.1}</property>
-            <property name="managementPort">${as.managementPort:9990}</property>
-
-            <!-- AS7-4070 -->
-            <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-            <property name="waitForPortsTimeoutInSeconds">8</property>
+            <property name="waitForPortsTimeoutInSeconds">10</property>
         </configuration>
     </container>
 

--- a/testsuite/integration/microprofile-tck/fault-tolerance/src/test/resources/arquillian-bootable.xml
+++ b/testsuite/integration/microprofile-tck/fault-tolerance/src/test/resources/arquillian-bootable.xml
@@ -9,17 +9,12 @@
             <property name="installDir">${install.dir}</property>
             <property name="jarFile">${bootable.jar}</property>
 
-            <property name="javaVmArguments">${server.jvm.args}</property>
-            <property name="jbossArguments">${jboss.args}</property>
-            <!-- -Djboss.inst is not necessarily needed, only in case the test case needs path to the instance it runs in.
-                 In the future, Arquillian should capable of injecting it into @ArquillianResource File or such. -->
+            <property name="javaVmArguments">${microprofile.jvm.args}</property>
+            <property name="managementAddress">127.0.0.1</property>
+            <property name="managementPort">9990</property>
             <property name="allowConnectingToRunningServer">true</property>
-            <property name="managementAddress">${node0:127.0.0.1}</property>
-            <property name="managementPort">${as.managementPort:9990}</property>
-
-            <!-- AS7-4070 -->
-            <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-            <property name="waitForPortsTimeoutInSeconds">8</property>
+            <property name="waitForPorts">9990</property>
+            <property name="waitForPortsTimeoutInSeconds">10</property>
         </configuration>
     </container>
 

--- a/testsuite/integration/microprofile-tck/jwt/src/test/resources/arquillian-bootable.xml
+++ b/testsuite/integration/microprofile-tck/jwt/src/test/resources/arquillian-bootable.xml
@@ -9,17 +9,12 @@
             <property name="installDir">${install.dir}</property>
             <property name="jarFile">${bootable.jar}</property>
 
-            <property name="javaVmArguments">${server.jvm.args}</property>
-            <property name="jbossArguments">${jboss.args}</property>
-            <!-- -Djboss.inst is not necessarily needed, only in case the test case neeeds path to the instance it runs in.
-                 In the future, Arquillian should capable of injecting it into @ArquillianResource File or such. -->
+            <property name="javaVmArguments">${microprofile.jvm.args}</property>
+            <property name="managementAddress">127.0.0.1</property>
+            <property name="managementPort">9990</property>
             <property name="allowConnectingToRunningServer">true</property>
-            <property name="managementAddress">${node0:127.0.0.1}</property>
-            <property name="managementPort">${as.managementPort:9990}</property>
-
-            <!-- AS7-4070 -->
-            <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-            <property name="waitForPortsTimeoutInSeconds">8</property>
+            <property name="waitForPorts">9990</property>
+            <property name="waitForPortsTimeoutInSeconds">10</property>
         </configuration>
     </container>
 

--- a/testsuite/integration/microprofile-tck/openapi/src/test/resources/arquillian-bootable.xml
+++ b/testsuite/integration/microprofile-tck/openapi/src/test/resources/arquillian-bootable.xml
@@ -9,17 +9,12 @@
             <property name="installDir">${install.dir}</property>
             <property name="jarFile">${bootable.jar}</property>
 
-            <property name="javaVmArguments">${server.jvm.args}</property>
-            <property name="jbossArguments">${jboss.args}</property>
-            <!-- -Djboss.inst is not necessarily needed, only in case the test case needs path to the instance it runs in.
-                 In the future, Arquillian should capable of injecting it into @ArquillianResource File or such. -->
+            <property name="javaVmArguments">${microprofile.jvm.args}</property>
+            <property name="managementAddress">127.0.0.1</property>
+            <property name="managementPort">9990</property>
             <property name="allowConnectingToRunningServer">true</property>
-            <property name="managementAddress">${node0:127.0.0.1}</property>
-            <property name="managementPort">${as.managementPort:9990}</property>
-
-            <!-- AS7-4070 -->
-            <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
-            <property name="waitForPortsTimeoutInSeconds">8</property>
+            <property name="waitForPorts">9990</property>
+            <property name="waitForPortsTimeoutInSeconds">10</property>
         </configuration>
     </container>
 


### PR DESCRIPTION
```
$ mvn clean test -Dts.bootable -Dmaven.repo.local=/home/fburzigo/projects/git/wildfly/wildfly/local-repo -DtestLogToFile=true -pl config,fault-tolerance,jwt,openapi/ -am
...
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running TestSuite
[INFO] Tests run: 230, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 37.295 s - in TestSuite
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 230, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for WildFly Test Suite: Integration - MicroProfile TCK 21.0.0.Beta1-SNAPSHOT:
[INFO] 
[INFO] WildFly Test Suite: Integration - MicroProfile TCK . SUCCESS [  2.247 s]
[INFO] WildFly Test Suite: Integration - MicroProfile TCK - Config SUCCESS [ 24.645 s]
[INFO] WildFly Test Suite: Integration - MicroProfile TCK - Fault Tolerance SUCCESS [06:16 min]
[INFO] WildFly Test Suite: Integration - MicroProfile - JWT SUCCESS [ 35.604 s]
[INFO] WildFly Test Suite: Integration - MicroProfile - OpenAPI TCK SUCCESS [ 44.074 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  08:03 min
[INFO] Finished at: 2020-08-21T17:58:11+02:00
[INFO] ------------------------------------------------------------------------

```