### PR TITLE
[WFLY-19147] Don't try and track different default procedure settings…

### DIFF
--- a/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/_private/MicroProfileHealthLogger.java
+++ b/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/_private/MicroProfileHealthLogger.java
@@ -53,7 +53,7 @@ public interface MicroProfileHealthLogger extends BasicLogger {
     OperationFailedException seeDownstream();
     */
 
-    @LogMessage(level = WARN)
-    @Message(id = 7, value = "Default procedures were disabled already, based on the following deployments configuration: %s")
-    void defaultProceduresDisabledByDeployments(String configuration);
+    @LogMessage(level = INFO)
+    @Message(id = 7, value = "The deployment %s configuration has specified that default MicroProfile Health procedures should be disabled; server-wide procedures will be disabled.")
+    void defaultProceduresDisabledByDeployment(String deploymentName);
 }


### PR DESCRIPTION
… between deployments; just log ones that turn of server procedures

@fabiobrz I don't think my idea of tracking which deployments do and don't disable default procedures and then warning about 'disagreements' is robust enough. CDIExtension just doesn't have the info needed to help MicroProfileHealthReporter discriminate between top-level deployments and subdeployments, so its easy to see how this could lead to incorrect WARNs. Perhaps now, and if not perhaps in the future when some change is made.

My commit here just switches to logging at INFO when a deployment overrides the global setting.